### PR TITLE
feat(project-config): Update audience evaluator and project config for new audience match types

### DIFF
--- a/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
+++ b/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
@@ -105,6 +105,7 @@
   <ItemGroup>
     <None Include="packages.config" />
     <EmbeddedResource Include="unsupported_version_datafile.json" />
+    <EmbeddedResource Include="typed_audience_datafile.json" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/OptimizelySDK.Tests/ProjectConfigTest.cs
+++ b/OptimizelySDK.Tests/ProjectConfigTest.cs
@@ -834,5 +834,15 @@ namespace OptimizelySDK.Tests
         {
             Assert.DoesNotThrow(() => ProjectConfig.Create(TestData.Datafile, null, null));
         }
+
+        [Test]
+        public void TestExperimentAudiencesRetrivedFromTypedAudiencesFirstThenFromAudiences()
+        {
+            var typedConfig = ProjectConfig.Create(TestData.TypedAudienceDatafile, null, null);
+            var experiment = typedConfig.GetExperimentFromKey("feat_with_var_test");
+
+            var expectedAudienceIds = new string[] { "3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643" };
+            Assert.That(expectedAudienceIds, Is.EquivalentTo(experiment.AudienceIds));
+        }
     }
 }

--- a/OptimizelySDK.Tests/TestData.cs
+++ b/OptimizelySDK.Tests/TestData.cs
@@ -26,6 +26,7 @@ namespace OptimizelySDK.Tests
         private static string cachedDataFile = null;
         private static string simpleABExperimentsDatafile = null;
         private static string unsupportedVersionDatafile = null;
+        private static string typedAudienceDatafile = null;
 
         public static string Datafile
         {
@@ -48,6 +49,14 @@ namespace OptimizelySDK.Tests
             get
             {
                 return unsupportedVersionDatafile ?? (unsupportedVersionDatafile = LoadJsonData("unsupported_version_datafile.json"));
+            }
+        }
+
+        public static string TypedAudienceDatafile
+        {
+            get
+            {
+                return typedAudienceDatafile ?? (typedAudienceDatafile = LoadJsonData("typed_audience_datafile.json"));
             }
         }
 

--- a/OptimizelySDK.Tests/typed_audience_datafile.json
+++ b/OptimizelySDK.Tests/typed_audience_datafile.json
@@ -1,0 +1,206 @@
+{
+	"version": "4",
+	"rollouts": [{
+			"experiments": [{
+				"status": "Running",
+				"key": "11488548027",
+				"layerId": "11551226731",
+				"trafficAllocation": [{
+					"entityId": "11557362669",
+					"endOfRange": 10000
+				}],
+				"audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
+				"variations": [{
+					"variables": [],
+					"id": "11557362669",
+					"key": "11557362669",
+					"featureEnabled": true
+				}],
+				"forcedVariations": {},
+				"id": "11488548027"
+			}],
+			"id": "11551226731"
+		},
+		{
+			"experiments": [{
+				"status": "Paused",
+				"key": "11630490911",
+				"layerId": "11638870867",
+				"trafficAllocation": [{
+					"entityId": "11475708558",
+					"endOfRange": 0
+				}],
+				"audienceIds": [],
+				"variations": [{
+					"variables": [],
+					"id": "11475708558",
+					"key": "11475708558",
+					"featureEnabled": false
+				}],
+				"forcedVariations": {},
+				"id": "11630490911"
+			}],
+			"id": "11638870867"
+		}
+	],
+	"anonymizeIP": false,
+	"projectId": "11624721371",
+	"variables": [],
+	"featureFlags": [{
+			"experimentIds": [],
+			"rolloutId": "11551226731",
+			"variables": [],
+			"id": "11477755619",
+			"key": "feat"
+		},
+		{
+			"experimentIds": [
+				"11564051718"
+			],
+			"rolloutId": "11638870867",
+			"variables": [{
+				"defaultValue": "x",
+				"type": "string",
+				"id": "11535264366",
+				"key": "x"
+			}],
+			"id": "11567102051",
+			"key": "feat_with_var"
+		}
+	],
+	"experiments": [{
+			"status": "Running",
+			"key": "feat_with_var_test",
+			"layerId": "11504144555",
+			"trafficAllocation": [{
+				"entityId": "11617170975",
+				"endOfRange": 10000
+			}],
+			"audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
+			"variations": [{
+				"variables": [{
+					"id": "11535264366",
+					"value": "xyz"
+				}],
+				"id": "11617170975",
+				"key": "variation_2",
+				"featureEnabled": true
+			}],
+			"forcedVariations": {},
+			"id": "11564051718"
+		},
+		{
+			"id": "1323241597",
+			"key": "typed_audience_experiment",
+			"layerId": "1630555627",
+			"status": "Running",
+			"variations": [{
+				"id": "1423767503",
+				"key": "A",
+				"variables": []
+			}],
+			"trafficAllocation": [{
+				"entityId": "1423767503",
+				"endOfRange": 10000
+			}],
+			"audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
+			"forcedVariations": {}
+		}
+	],
+	"audiences": [{
+			"id": "3468206642",
+			"name": "exactString",
+			"conditions": "[\"and\", [\"or\", [\"or\", {\"name\": \"house\", \"type\": \"custom_attribute\", \"value\": \"Gryffindor\"}]]]"
+		},
+		{
+			"id": "3988293898",
+			"name": "$$dummySubstringString",
+			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+		},
+		{
+			"id": "3988293899",
+			"name": "$$dummyExists",
+			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+		},
+		{
+			"id": "3468206646",
+			"name": "$$dummyExactNumber",
+			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+		},
+		{
+			"id": "3468206647",
+			"name": "$$dummyGtNumber",
+			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+		},
+		{
+			"id": "3468206644",
+			"name": "$$dummyLtNumber",
+			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+		},
+		{
+			"id": "3468206643",
+			"name": "$$dummyExactBoolean",
+			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+		}
+	],
+	"typedAudiences": [{
+			"id": "3988293898",
+			"name": "substringString",
+			"conditions": ["and", ["or", ["or", {"name": "house", "type": "custom_attribute", "match":"substring", "value":"Slytherin"}]]]
+		},
+		{
+			"id": "3988293899",
+			"name": "exists",
+			"conditions": ["and", ["or", ["or", {"name": "favorite_ice_cream", "type": "custom_attribute", "match":"exists"}]]]
+		},
+		{
+			"id": "3468206646",
+			"name": "exactNumber",
+			"conditions": ["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match": "exact", "value": 45.5}]]]
+		},
+		{
+			"id": "3468206647",
+			"name": "gtNumber",
+			"conditions": ["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match": "gt", "value": 70 }]]]
+		},
+		{
+			"id": "3468206644",
+			"name": "ltNumber",
+			"conditions": ["and", ["or", ["or", {"name": "lasers", "type": "custom_attribute", "match": "lt", "value": 1.0 }]]]
+		},
+		{
+			"id": "3468206643",
+			"name": "exactBoolean",
+			"conditions": ["and", ["or", ["or", {"name": "should_do_it", "type": "custom_attribute", "match": "exact", "value": true}]]]
+		}
+	],
+	"groups": [],
+	"attributes": [{
+			"key": "house",
+			"id": "594015"
+		},
+		{
+			"key": "lasers",
+			"id": "594016"
+		},
+		{
+			"key": "should_do_it",
+			"id": "594017"
+		},
+		{
+			"key": "favorite_ice_cream",
+			"id": "594018"
+		}
+	],
+	"botFiltering": false,
+	"accountId": "4879520872",
+	"events": [{
+		"key": "item_bought",
+		"id": "594089",
+		"experimentIds": [
+			"11564051718",
+			"1323241597"
+		]
+	}],
+	"revision": "3"
+}

--- a/OptimizelySDK/Entity/Audience.cs
+++ b/OptimizelySDK/Entity/Audience.cs
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using Newtonsoft.Json.Linq;
+
 namespace OptimizelySDK.Entity
 {
     public class Audience : Entity
@@ -30,19 +32,19 @@ namespace OptimizelySDK.Entity
         /// <summary>
         /// Audience Conditions
         /// </summary>
-        public string Conditions { get; set; }
-
-
-        private Newtonsoft.Json.Linq.JToken conditionList = null;
-
+        public object Conditions { get; set; }
+        
         /// <summary>
         /// De-serialized audience conditions
         /// </summary>
-        public Newtonsoft.Json.Linq.JToken ConditionList
+        public JToken ConditionList
         {
             get
             {
-                return (conditionList == null && string.IsNullOrEmpty(Conditions)) ? null : (conditionList = Utils.ConditionEvaluator.DecodeConditions(Conditions ?? string.Empty));
+                if (Conditions == null)
+                    return null;
+
+                return Conditions is string ? Utils.ConditionEvaluator.DecodeConditions((string)Conditions) : (JToken)Conditions;
             }
         }
     }

--- a/OptimizelySDK/ProjectConfig.cs
+++ b/OptimizelySDK/ProjectConfig.cs
@@ -192,6 +192,11 @@ namespace OptimizelySDK
         public Audience[] Audiences { get; set; }
 
         /// <summary>
+        /// Associative list of Typed Audiences.
+        /// </summary>
+        public Audience[] TypedAudiences { get; set; }
+
+        /// <summary>
         /// Associative list of FeatureFlags.
         /// </summary>
         public FeatureFlag[] FeatureFlags { get; set; }
@@ -221,6 +226,7 @@ namespace OptimizelySDK
             Events = Events ?? new Entity.Event[0];
             Attributes = Attributes ?? new Attribute[0];
             Audiences = Audiences ?? new Audience[0];
+            TypedAudiences = TypedAudiences ?? new Audience[0];
             FeatureFlags = FeatureFlags ?? new FeatureFlag[0];
             Rollouts = Rollouts ?? new Rollout[0];
 
@@ -232,6 +238,11 @@ namespace OptimizelySDK
             _AudienceIdMap = ConfigParser<Audience>.GenerateMap(entities: Audiences, getKey: a => a.Id.ToString(), clone: true);
             _FeatureKeyMap = ConfigParser<FeatureFlag>.GenerateMap(entities: FeatureFlags, getKey: f => f.Key, clone: true);
             _RolloutIdMap = ConfigParser<Rollout>.GenerateMap(entities: Rollouts, getKey: r => r.Id.ToString(), clone: true);
+
+            // Overwrite similar items in audience id map with typed audience id map.
+            var typedAudienceIdMap = ConfigParser<Audience>.GenerateMap(entities: TypedAudiences, getKey: a => a.Id.ToString(), clone: true);
+            foreach (var item in typedAudienceIdMap)
+                _AudienceIdMap[item.Key] = item.Value;
 
             foreach (Group group in Groups)
             {

--- a/OptimizelySDK/Utils/ExperimentUtils.cs
+++ b/OptimizelySDK/Utils/ExperimentUtils.cs
@@ -38,11 +38,12 @@ namespace OptimizelySDK.Utils
 
 
         /// <summary>
-        /// Representing whether user meets audience conditions to be in experiment or not
+        /// Check if the user meets audience conditions to be in experiment or not
         /// </summary>
         /// <param name="config">ProjectConfig Configuration for the project</param>
         /// <param name="experiment">Experiment Entity representing the experiment</param>
-        /// <param name="userAttributes">array Attributes of the user</returns>
+        /// <param name="userAttributes">Attributes of the user. Defaults to empty attributes array if not provided</param>
+        /// <returns>true if the user meets audience conditions to be in experiment, false otherwise.</returns>
         public static bool IsUserInExperiment(ProjectConfig config, Experiment experiment, UserAttributes userAttributes)
         {
             var audienceIds = experiment.AudienceIds;
@@ -50,8 +51,8 @@ namespace OptimizelySDK.Utils
             if (!audienceIds.Any())
                 return true;
 
-            if (userAttributes == null || !userAttributes.Any())
-                return false;
+            if (userAttributes == null)
+                userAttributes = new UserAttributes();
             
             var conditionEvaluator = new ConditionEvaluator();
             return audienceIds.Any(id => conditionEvaluator.Evaluate(config.GetAudience(id).ConditionList, userAttributes).GetValueOrDefault());


### PR DESCRIPTION
### Summary

This updates project config and the audience evaluator to finish the implementation of typed audience evaluation:

- In audience_evaluator, allow evaluation to continue when no user attributes are passed (previously we were immediately returning `false` when no attributes were passed)
- Update project_config to update audience_id_map with typed_audiences
- Added unit tests checking that all top-level methods that accept user attributes can bucket users into experiments or rollouts that use typed audiences.


### Test Plan

- New & existing unit tests
- Ran compatibility suite tests for typed audiences

## Summary
- The "what"; a concise description of each logical change
- Another change

The "why", or other context.

## Test plan

## Issues
- "THING-1234" or "Fixes #123"
